### PR TITLE
IRC module TLS support

### DIFF
--- a/modules/irc.py
+++ b/modules/irc.py
@@ -28,8 +28,18 @@ class Irc(XMPPModule):
 
 	def __init__(self, xmpp):
 		XMPPModule.__init__(self, xmpp)
-		self.bot = IrcClient(self.xmpp.config['irc']['nick'])
-		self.bot.connect(self.xmpp.config['irc']['server'], port=self.xmpp.config['irc']['port'])
+		self.bot = IrcClient(
+			nickname                 = self.xmpp.config['irc']['nick'],
+			tls_certificate_file     = self.xmpp.config['irc']['tls_certificate_file'],
+			tls_certificate_keyfile  = self.xmpp.config['irc']['tls_certificate_keyfile'],
+			tls_certificate_password = self.xmpp.config['irc']['tls_certificate_password']
+		)
+		self.bot.connect(
+			hostname   = self.xmpp.config['irc']['server'],
+			port       = self.xmpp.config['irc']['port'],
+			tls        = self.xmpp.config['irc']['tls'],
+			tls_verify = self.xmpp.config['irc']['tls_verify']
+		)
 		self.bot.module = self
 	
 		self._create_thread()

--- a/modules/irc.py
+++ b/modules/irc.py
@@ -30,15 +30,15 @@ class Irc(XMPPModule):
 		XMPPModule.__init__(self, xmpp)
 		self.bot = IrcClient(
 			nickname                 = self.xmpp.config['irc']['nick'],
-			tls_certificate_file     = self.xmpp.config['irc']['tls_certificate_file'],
-			tls_certificate_keyfile  = self.xmpp.config['irc']['tls_certificate_keyfile'],
-			tls_certificate_password = self.xmpp.config['irc']['tls_certificate_password']
+			tls_certificate_file     = self.xmpp.config['irc'].get('tls_certificate_file'),
+			tls_certificate_keyfile  = self.xmpp.config['irc'].get('tls_certificate_keyfile'),
+			tls_certificate_password = self.xmpp.config['irc'].get('tls_certificate_password')
 		)
 		self.bot.connect(
 			hostname   = self.xmpp.config['irc']['server'],
 			port       = self.xmpp.config['irc']['port'],
-			tls        = self.xmpp.config['irc']['tls'],
-			tls_verify = self.xmpp.config['irc']['tls_verify']
+			tls        = self.xmpp.config['irc'].get('tls'),
+			tls_verify = self.xmpp.config['irc'].get('tls_verify')
 		)
 		self.bot.module = self
 	


### PR DESCRIPTION
Fixes #19. Should work, but only compile-tested as I am too lazy to spin up a halibot instance now. richteer, test.

To enable tls support just set irc->tls to `true`, and it should use tls encryption without host verification, which can be done with the remaining config options.
